### PR TITLE
Update requirements.txt

### DIFF
--- a/elysium/requirements.txt
+++ b/elysium/requirements.txt
@@ -4,4 +4,4 @@ py-solc-x==1.0.0
 web3==5.30.0
 docker==6.0.0
 numpy==1.22.3
-tqdm==4.51.0
+tqdm>=4.51.0


### PR DESCRIPTION
Fix

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
datasets 2.4.0 requires tqdm>=4.62.1, but you have tqdm 4.51.0 which is incompatible.
```
